### PR TITLE
Fix option parsing for destination arg

### DIFF
--- a/radosgw_agent/cli.py
+++ b/radosgw_agent/cli.py
@@ -81,7 +81,7 @@ def parse_args():
     parser.add_argument(
         'destination',
         type=check_endpoint,
-        nargs=1 if 'destination' not in defaults else '?',
+        nargs=None if 'destination' not in defaults else '?',
         help='radosgw endpoint to which to sync '
         '(e.g. http://zone2.example.org:8080)',
         )


### PR DESCRIPTION
As mentionned at http://docs.python.org/3.4/library/argparse.html#nargs,
nargs=1 will not provide the default behaviour, but instead will produce
a list of args, and that is not what we want.

This patch uses nargs=None to provide default behaviour instead.

As it is a positionnal argument, we can't use required option.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
