### PR TITLE
Rename variable to match option parsing variable name

### DIFF
--- a/radosgw_agent/cli.py
+++ b/radosgw_agent/cli.py
@@ -174,7 +174,7 @@ class TestHandler(BaseHTTPRequestHandler):
     num_workers = None
     lock_timeout = None
     max_entries = None
-    data_log_window = 30
+    rgw_data_log_window = 30
     src = None
     dest = None
 
@@ -200,7 +200,7 @@ class TestHandler(BaseHTTPRequestHandler):
             if sync_cls is not None:
                 syncer = sync_cls(TestHandler.src, TestHandler.dest,
                                   TestHandler.max_entries,
-                                  data_log_window=TestHandler.data_log_window,
+                                  rgw_data_log_window=TestHandler.rgw_data_log_window,
                                   object_timeout=TestHandler.object_timeout)
                 syncer.prepare()
                 syncer.sync(
@@ -273,7 +273,7 @@ def main():
         TestHandler.num_workers = args.num_workers
         TestHandler.lock_timeout = args.lock_timeout
         TestHandler.max_entries = args.max_entries
-        TestHandler.data_log_window = args.data_log_window
+        TestHandler.rgw_data_log_window = args.rgw_data_log_window
         TestHandler.object_sync_timeout = args.object_sync_timeout
         server = HTTPServer((args.test_server_host, args.test_server_port),
                             TestHandler)
@@ -289,7 +289,7 @@ def main():
 
     meta_syncer = meta_cls(src, dest, args.max_entries)
     data_syncer = data_cls(src, dest, args.max_entries,
-                           data_log_window=args.rgw_data_log_window,
+                           rgw_data_log_window=args.rgw_data_log_window,
                            object_timeout=args.object_sync_timeout)
 
     # fetch logs first since data logs need to wait before becoming usable

--- a/radosgw_agent/sync.py
+++ b/radosgw_agent/sync.py
@@ -185,11 +185,11 @@ class DataSyncerInc(IncrementalSyncer):
         super(DataSyncerInc, self).__init__(*args, **kwargs)
         self.worker_cls = worker.DataWorkerIncremental
         self.type = 'data'
-        self.data_log_window = kwargs.get('data_log_window', 30)
+        self.rgw_data_log_window = kwargs.get('rgw_data_log_window', 30)
 
     def wait_until_ready(self):
         log.info('waiting to make sure bucket log is consistent')
-        while time.time() < self.prepared_at + self.data_log_window:
+        while time.time() < self.prepared_at + self.rgw_data_log_window:
             time.sleep(1)
 
 
@@ -199,7 +199,7 @@ class DataSyncerFull(Syncer):
         super(DataSyncerFull, self).__init__(*args, **kwargs)
         self.worker_cls = worker.DataWorkerFull
         self.type = 'data'
-        self.data_log_window = kwargs.get('data_log_window', 30)
+        self.rgw_data_log_window = kwargs.get('rgw_data_log_window', 30)
 
     def prepare(self):
         self.init_num_shards()
@@ -229,7 +229,7 @@ class DataSyncerFull(Syncer):
 
     def wait_until_ready(self):
         log.info('waiting to make sure bucket log is consistent')
-        while time.time() < self.prepared_at + self.data_log_window:
+        while time.time() < self.prepared_at + self.rgw_data_log_window:
             time.sleep(1)
 
 


### PR DESCRIPTION
The data_log_window variable was renamed rgw_data_log_window
in the option parser, but not elsewhere.

This patch fixes it.

Signed-off-by: Christophe Courtaut christophe.courtaut@gmail.com
