### PR TITLE
#10518: add fixes from v1.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+radosgw-agent (1.2-1) precise; urgency=low
+
+  * new upstream release
+
+ -- Sandon Van Ness <sandon@inktank.com>  Wed, 02 April 2014 11:25:54 -0800
+
 radosgw-agent (1.1-1) precise; urgency=low
 
   * new upstream release 

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -1,8 +1,8 @@
 %define name radosgw-agent
-%define version 1.1
-%define unmangled_version 1.1
-%define unmangled_version 1.1
-%define release 1
+%define version 1.2
+%define unmangled_version 1.2
+%define unmangled_version 1.2
+%define release 0
 
 Summary: Synchronize users and data between radosgw clusters
 Name: %{name}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if pyversion < (2, 7) or (3, 0) <= pyversion <= (3, 1):
 
 setup(
     name='radosgw-agent',
-    version='1.1',
+    version='1.2',
     packages=find_packages(),
 
     author='Josh Durgin',


### PR DESCRIPTION
As discussed in `#ceph-devel` today, there are four commits in the `v1.2` branch that were not yet present on master.

1. 17fa0f7dc85f658547dd79a5416f55fa709a4956 , "Branch for 1.2 release."
2. cc845481a60d6d0da92879e5ef411d8d89c572f3, "Update Debian Changelog."
3. 86b09494541887911348122154bb121320aa9b94, "Change dependencies for requests."
4. 6978983587fb37b79d93c64faaf6bdcd8e7079be, "client: fix unicode handling"

Commits `#1` and `#2` are the ones we need, and they are in this PR.

Commit `#3`, "Change dependencies for requests" is not needed because the code in master does not depend on python-requests directly any more (only python-boto).

Commit `#4` "client: fix unicode handling" is already on master as cb32aadc0881da5f0335c179aab3733bd93cbb4e, so that one's done.

This resolves http://tracker.ceph.com/issues/10518