### PR TITLE
packaging: RPM .spec cleanup

### DIFF
--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -17,7 +17,7 @@ The Ceph RADOS Gateway agent replicates the data of a master zone to a
 secondary zone.
 
 %prep
-%setup -n %{name}-%{version} -n %{name}-%{version}
+%setup -q
 
 %build
 python setup.py build

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -5,10 +5,7 @@ Release: 0
 Source0: %{name}-%{version}.tar.gz
 License: MIT
 Group: Development/Libraries
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Prefix: %{_prefix}
 BuildArch: noarch
-Vendor: Josh Durgin <josh.durgin@inktank.com>
 Requires: python-argparse
 Requires: PyYAML
 Requires: python-boto >= 2.2.2

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -2,7 +2,7 @@ Summary: Synchronize users and data between radosgw clusters
 Name: radosgw-agent
 Version: 1.2
 Release: 0
-Source0: %{name}-%{version}.tar.gz
+Source0: https://pypi.python.org/packages/source/r/%{name}/%{name}-%{version}.tar.gz
 License: MIT
 Group: Development/Libraries
 BuildArch: noarch

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -31,9 +31,6 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/ceph/radosgw-agent
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/ceph/radosgw-agent
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/run/ceph/radosgw-agent
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 %files
 %defattr(-,root,root)
 %doc LICENSE

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -32,7 +32,6 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/ceph/radosgw-agent
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/run/ceph/radosgw-agent
 
 %files
-%defattr(-,root,root)
 %doc LICENSE
 %dir %{_sysconfdir}/ceph/radosgw-agent
 %dir %{_localstatedir}/log/ceph/radosgw-agent

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -10,6 +10,8 @@ Requires: python-argparse
 Requires: PyYAML
 Requires: python-boto >= 2.2.2
 Requires: python-boto < 3.0.0
+BuildRequires: python-devel
+BuildRequires: python-setuptools
 URL: https://github.com/ceph/radosgw-agent
 
 %description

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -1,14 +1,8 @@
-%define name radosgw-agent
-%define version 1.2
-%define unmangled_version 1.2
-%define unmangled_version 1.2
-%define release 0
-
 Summary: Synchronize users and data between radosgw clusters
-Name: %{name}
-Version: %{version}
-Release: %{release}
-Source0: %{name}-%{unmangled_version}.tar.gz
+Name: radosgw-agent
+Version: 1.2
+Release: 0
+Source0: %{name}-%{version}.tar.gz
 License: MIT
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -25,7 +19,7 @@ Url: https://github.com/ceph/radosgw-agent
 UNKNOWN
 
 %prep
-%setup -n %{name}-%{unmangled_version} -n %{name}-%{unmangled_version}
+%setup -n %{name}-%{version} -n %{name}-%{version}
 
 %build
 python setup.py build

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -10,7 +10,7 @@ Requires: python-argparse
 Requires: PyYAML
 Requires: python-boto >= 2.2.2
 Requires: python-boto < 3.0.0
-Url: https://github.com/ceph/radosgw-agent
+URL: https://github.com/ceph/radosgw-agent
 
 %description
 UNKNOWN

--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -13,7 +13,8 @@ Requires: python-boto < 3.0.0
 URL: https://github.com/ceph/radosgw-agent
 
 %description
-UNKNOWN
+The Ceph RADOS Gateway agent replicates the data of a master zone to a
+secondary zone.
 
 %prep
 %setup -n %{name}-%{version} -n %{name}-%{version}


### PR DESCRIPTION
This pull request cleans up several small things in the RPM spec file.

It removes extraneous variables and unneeded RPM tags, adds a description for the package, and removes older RPM conventions that are no longer relevant on RHEL 6 and newer.