### PR TITLE
packaging: use dist tag in RPM Release field

### DIFF
--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -1,7 +1,7 @@
 Summary: Synchronize users and data between radosgw clusters
 Name: radosgw-agent
 Version: 1.2
-Release: 0
+Release: 0%{?dist}
 Source0: https://pypi.python.org/packages/source/r/%{name}/%{name}-%{version}.tar.gz
 License: MIT
 Group: Development/Libraries


### PR DESCRIPTION
This change adds ".el6", ".el7", etc to the end of the RPM filename.

More information about the dist tag can be found at http://fedoraproject.org/wiki/Packaging:DistTag
