### PR TITLE
set the stream logging before anything else

### DIFF
--- a/radosgw_agent/cli.py
+++ b/radosgw_agent/cli.py
@@ -262,6 +262,9 @@ def main():
     sh.setFormatter(util.log.color_format())
     sh.setLevel(console_loglevel)
 
+    agent_logger = logging.getLogger('radosgw_agent')
+    agent_logger.addHandler(sh)
+
     # File handler
     log_file = args.log_file or 'radosgw_agent.log'
     fh = logging.handlers.WatchedFileHandler(log_file)
@@ -269,8 +272,6 @@ def main():
     fh.setFormatter(logging.Formatter(util.log.BASE_FORMAT))
 
     root_logger.addHandler(fh)
-    agent_logger = logging.getLogger('radosgw_agent')
-    agent_logger.addHandler(sh)
 
     dest = args.destination
     dest.access_key = args.dest_access_key


### PR DESCRIPTION
Trying to get a fix in for http://tracker.ceph.com/issues/11012 I realized that if the streamhandler (terminal logger) is not set as soon as possible no proper reporting will happen.

This fixes that.

Before:

    radosgw-agent --test-server-host localhost --test-server-port 8888 --src-access-key SRC_ACCESS_KEY --src-secret-key SRC_SECRET_KEY --dest-access-key DEST_ACCESS_KEY --dest-secret-key DEST_SECRET_KEY http://localhost:8888
    No handlers could be found for logger "radosgw_agent"

After:

    radosgw-agent --test-server-host localhost --test-server-port 8888 --src-access-key SRC_ACCESS_KEY --src-secret-key SRC_SECRET_KEY --dest-access-key DEST_ACCESS_KEY --dest-secret-key DEST_SECRET_KEY http://localhost:8888
    2015-03-09 13:51:49,149 6040 [radosgw_agent][ERROR ] Traceback (most recent call last):
    2015-03-09 13:51:49,149 6040 [radosgw_agent][ERROR ]   File "/Users/alfredo/python/radosgw-agent/radosgw_agent/util/decorators.py", line 69, in newfunc
    2015-03-09 13:51:49,149 6040 [radosgw_agent][ERROR ]     return f(*a, **kw)
    2015-03-09 13:51:49,149 6040 [radosgw_agent][ERROR ]   File "/Users/alfredo/python/radosgw-agent/radosgw_agent/cli.py", line 270, in main
    2015-03-09 13:51:49,149 6040 [radosgw_agent][ERROR ]     fh = logging.handlers.WatchedFileHandler(log_file)
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]   File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 391, in __init__
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]     logging.FileHandler.__init__(self, filename, mode, encoding, delay)
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]   File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 903, in __init__
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]     StreamHandler.__init__(self, self._open())
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]   File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 926, in _open
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]     stream = open(self.baseFilename, self.mode)
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ] IOError: [Errno 2] No such file or directory: '/var/log/ceph/radosgw-agent/radosgw-agent.log'
    2015-03-09 13:51:49,150 6040 [radosgw_agent][ERROR ]
