### PR TITLE
fallback to cwd if log location is unavailable

### DIFF
--- a/radosgw_agent/cli.py
+++ b/radosgw_agent/cli.py
@@ -266,8 +266,13 @@ def main():
     agent_logger.addHandler(sh)
 
     # File handler
-    log_file = args.log_file or 'radosgw_agent.log'
-    fh = logging.handlers.WatchedFileHandler(log_file)
+    log_file = args.log_file or 'radosgw-agent.log'
+    try:
+        fh = logging.handlers.WatchedFileHandler(log_file)
+    except IOError:
+        # if the location is not present, fallback to cwd
+        fh = logging.handlers.WatchedFileHandler('radosgw-agent.log')
+
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(logging.Formatter(util.log.BASE_FORMAT))
 

--- a/radosgw_agent/cli.py
+++ b/radosgw_agent/cli.py
@@ -269,7 +269,10 @@ def main():
     log_file = args.log_file or 'radosgw-agent.log'
     try:
         fh = logging.handlers.WatchedFileHandler(log_file)
-    except IOError:
+    except IOError as err:
+        agent_logger.warning('unable to use log location: %s' % log_file)
+        agent_logger.warning(err)
+        agent_logger.warning('will fallback to ./radosgw-agent.log')
         # if the location is not present, fallback to cwd
         fh = logging.handlers.WatchedFileHandler('radosgw-agent.log')
 


### PR DESCRIPTION
tiny PR that just ensures that there will always be a log location that will fallback to the cwd if necessary, while letting the user know:

    $ radosgw-agent --test-server-host localhost --test-server-port 8888 --src-access-key SRC_ACCESS_KEY --src-secret-key SRC_SECRET_KEY --dest-access-key DEST_ACCESS_KEY --dest-secret-key DEST_SECRET_KEY http://localhost:8888
    2015-03-10 14:52:07,551 2141 [radosgw_agent][WARNIN] unable to use log location: /var/log/ceph/radosgw-agent/radosgw-agent.log
    2015-03-10 14:52:07,551 2141 [radosgw_agent][WARNIN] [Errno 2] No such file or directory: '/var/log/ceph/radosgw-agent/radosgw-agent.log'
    2015-03-10 14:52:07,552 2141 [radosgw_agent][WARNIN] will fallback to ./radosgw-agent.log


Reference issue: http://tracker.ceph.com/issues/11012