### PR TITLE
IPV6 support 

### DIFF
--- a/radosgw_agent/client.py
+++ b/radosgw_agent/client.py
@@ -66,7 +66,7 @@ def parse_endpoint(endpoint):
         raise exc.InvalidProtocol('invalid protocol %r' % url.scheme)
     if not url.hostname:
         raise exc.InvalidHost('no hostname in %r' % endpoint)
-    return Endpoint(url.hostname, url.port, url.scheme == 'https')
+    return Endpoint(url.netloc, url.port, url.scheme == 'https')
 
 code_to_exc = {
     404: exc.NotFound,

--- a/radosgw_agent/tests/conftest.py
+++ b/radosgw_agent/tests/conftest.py
@@ -1,8 +1,13 @@
 import logging
 import sys
+import os
 
-# this console logging configuration is basically just to be able to see output in
-# tests, and this file gets executed by py.test when it runs, so we get that for free.
+# set an environ variable that tells us that we are really testing
+os.environ['PYTEST'] = '1'
+
+# this console logging configuration is basically just to be able to see output
+# in tests, and this file gets executed by py.test when it runs, so we get that
+# for free.
 
 # Console Logger
 sh = logging.StreamHandler()

--- a/radosgw_agent/tests/test_client.py
+++ b/radosgw_agent/tests/test_client.py
@@ -14,6 +14,10 @@ def endpoints():
     return [
         ('http://example.org', 'example.org', 80, False),
         ('https://example.org', 'example.org', 443, True),
+        ('https://[e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', '[e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', 443, True),
+        ('http://[e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', '[e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', 80, False),
+        ('http://[e39:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]:8080', '[e39:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', 8080, False),
+        ('http://e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922', '[e40:92be:ab1c:c9c1:3e2e:dbf6:57c6:8922]', 80, False),
         ('https://example.org:8080', 'example.org', 8080, True),
         ('https://example.org:8080/', 'example.org', 8080, True),
         ('http://example.org:81/a/b/c?b#d', 'example.org', 81, False),
@@ -176,6 +180,7 @@ def test_endpoint_port_specified():
     endpoint = client.Endpoint('example.org', 443, True)
     assert endpoint.port == 443
 
+
 def test_endpoint_equality():
     default_port = client.Endpoint('a.org', None, True)
     secure = client.Endpoint('a.org', 443, True)
@@ -183,6 +188,7 @@ def test_endpoint_equality():
     assert default_port == secure
     assert secure == insecure
     assert insecure == default_port
+
 
 def test_endpoint_inequality():
     base = client.Endpoint('a.org', 80, True)

--- a/radosgw_agent/tests/util/test_network.py
+++ b/radosgw_agent/tests/util/test_network.py
@@ -1,0 +1,48 @@
+import pytest
+from radosgw_agent.util import network
+import random
+
+
+def valid_ipv6_addr(ports=False, brackets=False, addresses=20):
+    max_rand_int = 16**4
+
+    def generate(brackets, ports):
+        address = ":".join(
+            ("%x" % random.randint(0, max_rand_int) for i in range(8))
+        )
+        if brackets:
+            address =  '[%s]' % address
+        if ports:
+            address = '%s:8080' % address
+        return address
+    return [generate(brackets, ports) for i in range(addresses)]
+
+
+def invalid_ipv6_addr():
+    return [
+        '',
+        1,
+        'some address',
+        '192.1.1.1',
+        '::!',
+    ]
+
+
+class TestIsIPV6(object):
+
+    @pytest.mark.parametrize('address', valid_ipv6_addr())
+    def test_passes_valid_addresses(self, address):
+        assert network.is_ipv6(address) is True
+
+    @pytest.mark.parametrize('address', valid_ipv6_addr(brackets=True))
+    def test_passes_valid_addresses_with_brackets(self, address):
+        assert network.is_ipv6(address) is True
+
+    @pytest.mark.parametrize('address', invalid_ipv6_addr())
+    def test_catches_invalid_addresses(self, address):
+        assert network.is_ipv6(address) is False
+
+    @pytest.mark.parametrize('address', valid_ipv6_addr(ports=True, brackets=True))
+    def test_passes_valid_addresses_with_brackets_and_ports(self, address):
+        assert network.is_ipv6(address) is True
+

--- a/radosgw_agent/util/network.py
+++ b/radosgw_agent/util/network.py
@@ -1,0 +1,20 @@
+import socket
+
+
+def is_ipv6(address):
+    """
+    Check if an address is an IPV6 one, but trim commonly used brackets as the
+    ``socket`` module complains about them.
+    """
+    if not isinstance(address, str):
+        return False
+
+    if address.startswith('['):  # assume we need to split on possible port
+        address = address.split(']:')[0]
+    # strip leading/trailing brackets so inet_pton understands the address
+    address = address.strip('[]')
+    try:
+        socket.inet_pton(socket.AF_INET6, address)
+    except socket.error:  # not a valid address
+        return False
+    return True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26
+envlist = py26, py27
 
 [testenv]
 deps=


### PR DESCRIPTION
Does a bunch of parsing and checking to ensure that we can handle IPV6 endpoints and those can be passed onto boto.

`boto` is not yet fixed, but for now, this allows us to at least handle the input properly so that `boto` can be happy when it does support it on their end.

Reference issue: http://tracker.ceph.com/issues/12030