### PR TITLE
Fix conf not found error when using init script to restart radosgw-agent

### DIFF
--- a/init-radosgw-agent
+++ b/init-radosgw-agent
@@ -79,12 +79,12 @@ case "$1" in
         fi
         ;;
         restart)
-                $0 stop $name
+                $0 stop $config_path
                 if is_running; then
                         echo "Unable to stop, will not attempt to start"
                         exit 1
                 fi
-                $0 start $name
+                $0 start $config_path
         ;;
         status)
                 if is_running; then


### PR DESCRIPTION
Init script wrongly passed conf file name recursively in restarting case, so conf file not found after re-entry init script. It should pass initial conf file path.

Signed-off-by: Zhi Zhang zhangz.david@outlook.com