### PR TITLE
update the minimum boto version required

### DIFF
--- a/radosgw-agent.spec
+++ b/radosgw-agent.spec
@@ -8,7 +8,7 @@ Group: Development/Libraries
 BuildArch: noarch
 Requires: python-argparse
 Requires: PyYAML
-Requires: python-boto >= 2.2.2
+Requires: python-boto >= 2.10.0
 Requires: python-boto < 3.0.0
 BuildRequires: python-devel
 BuildRequires: python-setuptools

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ metadata = dict(
 
 
 install_requires = [
-    'boto >=2.2.2,<3.0.0',
+    'boto >=2.10.0,<3.0.0',
     'PyYAML',
 ]
 


### PR DESCRIPTION
From what I could check, at least from boto version 2.10.0 the required parameters the agent uses, exists. This pull request sets the minimum version to that.

Fixes: http://tracker.ceph.com/issues/13377