### PR TITLE
prevent looking at state if there is none in the response

### DIFF
--- a/radosgw_agent/worker.py
+++ b/radosgw_agent/worker.py
@@ -287,6 +287,7 @@ class DataWorker(Worker):
                 raise SyncFailed('object copy state not found')
             except Exception as e:
                 log.debug('error geting op state: %s', e, exc_info=True)
+                log.info('will try to get op state again')
                 time.sleep(1)
         # timeout expired
         raise SyncTimedOut()

--- a/radosgw_agent/worker.py
+++ b/radosgw_agent/worker.py
@@ -272,6 +272,9 @@ class DataWorker(Worker):
                                             local_op_id,
                                             bucket, obj)
                 log.debug('op state is %s', state)
+                if not state:
+                    time.sleep(1)
+                    continue
                 state = state[0]['state']
                 if state == 'complete':
                     return


### PR DESCRIPTION
This isn't really breaking, but since we log all exceptions at the end it looks like it is breaking and halting the operation.

The code shouldn't keep going to parse the empty `op_state`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1336532